### PR TITLE
Remove batch processing

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -34,4 +34,4 @@ end
 morph_names = members.map { |w| w[:wikiname] }
 toget = morph_names | names.values.flatten.uniq
 
-EveryPolitician::Wikidata.scrape_wikidata(names: { en: toget }, batch_size: 25)
+EveryPolitician::Wikidata.scrape_wikidata(names: { en: toget })


### PR DESCRIPTION
Scraper is failing with a timeout.
(https://morph.io/tmtmtmtm/us-senators-wikidata)

It is believed that the use of batch processing is causing this.
